### PR TITLE
Feat/enrollment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,35 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.5</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath/>
 	</parent>
+
 	<groupId>com.ironhack</groupId>
 	<artifactId>lms</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>lms</name>
 	<description>Module 2 final project for IronHack</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+
 	<properties>
 		<java.version>17</java.version>
+		<!-- for springdoc -->
+		<springdoc.version>2.6.0</springdoc.version>
+		<!-- for JJWT (used when we implement JWT issuing) -->
+		<jjwt.version>0.12.5</jjwt.version>
 	</properties>
+
 	<dependencies>
+		<!-- Core -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -38,25 +43,40 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-validation</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
 
+		<!-- DB -->
 		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+		<!-- Flyway core -->
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+		</dependency>
+
+		<!-- NEW: Flyway database support for MySQL/MariaDB -->
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-mysql</artifactId>
+		</dependency>
+
+		<!-- OpenAPI / Swagger UI -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>${springdoc.version}</version>
+		</dependency>
+
+		<!-- Lombok -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
+
+		<!-- Tests -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -67,6 +87,37 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- H2 for tests (lets you run repository tests without local MySQL) -->
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- JWT (add now; wire later in Iteration 2) -->
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>${jjwt.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>${jjwt.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>${jjwt.version}</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testng</groupId>
+			<artifactId>testng</artifactId>
+			<version>RELEASE</version>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -75,6 +126,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
+					<release>${java.version}</release>
 					<annotationProcessorPaths>
 						<path>
 							<groupId>org.projectlombok</groupId>
@@ -86,16 +138,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/src/main/java/com/ironhack/lms/config/DataInitializer.java
+++ b/src/main/java/com/ironhack/lms/config/DataInitializer.java
@@ -1,0 +1,42 @@
+package com.ironhack.lms.config;
+
+import com.ironhack.lms.domain.user.Instructor;
+import com.ironhack.lms.domain.user.Role;
+import com.ironhack.lms.domain.user.Student;
+import com.ironhack.lms.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@RequiredArgsConstructor
+public class DataInitializer {
+
+    private final PasswordEncoder encoder;
+
+    @Bean
+    CommandLineRunner initUsers(UserRepository repo) {
+        return args -> {
+            if (repo.count() == 0) {
+                var s = Student.builder()
+                        .email("student@lms.local")
+                        .passwordHash(encoder.encode("password"))
+                        .fullName("Stu Dent")
+                        .role(Role.STUDENT)
+                        .studentNumber("S-001")
+                        .build();
+                var i = Instructor.builder()
+                        .email("instructor@lms.local")
+                        .passwordHash(encoder.encode("password"))
+                        .fullName("In Structor")
+                        .role(Role.INSTRUCTOR)
+                        .bio("Teaches Java")
+                        .build();
+                repo.save(s);
+                repo.save(i);
+            }
+        };
+    }
+}

--- a/src/main/java/com/ironhack/lms/config/JwtAuthFilter.java
+++ b/src/main/java/com/ironhack/lms/config/JwtAuthFilter.java
@@ -1,0 +1,48 @@
+package com.ironhack.lms.config;
+
+import com.ironhack.lms.service.auth.AppUserDetailsService;
+import com.ironhack.lms.service.auth.JwtService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtService jwt;
+    private final AppUserDetailsService uds;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+            throws ServletException, IOException {
+
+        String auth = req.getHeader(HttpHeaders.AUTHORIZATION);
+        if (auth != null && auth.startsWith("Bearer ")) {
+            String token = auth.substring(7);
+            try {
+                String username = jwt.extractUsername(token);
+                if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                    UserDetails user = uds.loadUserByUsername(username);
+                    if (jwt.isValid(token, user)) {
+                        var authToken = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+                        authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
+                        SecurityContextHolder.getContext().setAuthentication(authToken);
+                    }
+                }
+            } catch (Exception ignored) {}
+        }
+        chain.doFilter(req, res);
+    }
+}

--- a/src/main/java/com/ironhack/lms/config/SecurityConfig.java
+++ b/src/main/java/com/ironhack/lms/config/SecurityConfig.java
@@ -1,0 +1,93 @@
+package com.ironhack.lms.config;
+
+import com.ironhack.lms.service.auth.AppUserDetailsService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthFilter jwtFilter;
+    private final AppUserDetailsService uds;
+
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(c -> c.configurationSource(corsConfigurationSource()))
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/**", "/api/ping", "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/courses/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint((req, res, ex) -> {
+                            res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            res.setContentType("application/json");
+                            res.getWriter().write("{\"error\":\"unauthorized\"}");
+                        })
+                        .accessDeniedHandler((req, res, ex) -> {
+                            res.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                            res.setContentType("application/json");
+                            res.getWriter().write("{\"error\":\"forbidden\"}");
+                        })
+                )
+                .authenticationProvider(authProvider())                    // <-- uses ctor-injected UDS
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    AuthenticationProvider authProvider() {
+        var provider = new DaoAuthenticationProvider(uds);
+        provider.setPasswordEncoder(passwordEncoder());
+        return provider;
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    AuthenticationManager authenticationManager(AuthenticationConfiguration cfg) throws Exception {
+        return cfg.getAuthenticationManager();
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        var cfg = new CorsConfiguration();
+        cfg.setAllowedOriginPatterns(List.of("*"));
+        cfg.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
+        cfg.setAllowedHeaders(List.of("Authorization","Content-Type","X-Requested-With"));
+        cfg.setExposedHeaders(List.of("Location"));
+        cfg.setAllowCredentials(false);
+        var source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", cfg);
+        return source;
+    }
+}

--- a/src/main/java/com/ironhack/lms/domain/course/Assignment.java
+++ b/src/main/java/com/ironhack/lms/domain/course/Assignment.java
@@ -1,0 +1,37 @@
+package com.ironhack.lms.domain.course;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter @Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "assignment")
+public class Assignment {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "course_id")
+    private Course course;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String instructions;
+
+    @Column(name = "due_at")
+    private Instant dueAt;
+
+    @Column(name = "max_points", nullable = false)
+    private int maxPoints;
+
+    @Column(name = "allow_late", nullable = false)
+    private boolean allowLate = false;
+}

--- a/src/main/java/com/ironhack/lms/domain/course/Course.java
+++ b/src/main/java/com/ironhack/lms/domain/course/Course.java
@@ -1,0 +1,45 @@
+package com.ironhack.lms.domain.course;
+
+import com.ironhack.lms.domain.user.Instructor;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter @Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "course")
+public class Course {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "instructor_id")
+    private Instructor instructor;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private CourseStatus status = CourseStatus.DRAFT;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "published_at")
+    private Instant publishedAt;
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) createdAt = Instant.now();
+        if (status == null) status = CourseStatus.DRAFT;
+    }
+}

--- a/src/main/java/com/ironhack/lms/domain/course/CourseStatus.java
+++ b/src/main/java/com/ironhack/lms/domain/course/CourseStatus.java
@@ -1,0 +1,2 @@
+package com.ironhack.lms.domain.course;
+public enum CourseStatus { DRAFT, PUBLISHED, ARCHIVED }

--- a/src/main/java/com/ironhack/lms/domain/course/Lesson.java
+++ b/src/main/java/com/ironhack/lms/domain/course/Lesson.java
@@ -1,0 +1,29 @@
+package com.ironhack.lms.domain.course;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "lesson")
+public class Lesson {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "course_id")
+    private Course course;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content_url", length = 2048)
+    private String contentUrl;
+
+    @Column(name = "order_index", nullable = false)
+    private int orderIndex;
+}

--- a/src/main/java/com/ironhack/lms/domain/enrollment/Enrollment.java
+++ b/src/main/java/com/ironhack/lms/domain/enrollment/Enrollment.java
@@ -1,0 +1,42 @@
+package com.ironhack.lms.domain.enrollment;
+
+import com.ironhack.lms.domain.course.Course;
+import com.ironhack.lms.domain.user.Student;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.Instant;
+
+@Getter @Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "enrollment",
+        uniqueConstraints = @UniqueConstraint(name = "uq_enroll", columnNames = {"student_id","course_id"}))
+public class Enrollment {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "student_id")
+    private Student student;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "course_id")
+    private Course course;
+
+    @Column(name = "enrolled_at", nullable = false)
+    private Instant enrolledAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private EnrollmentStatus status = EnrollmentStatus.ACTIVE;
+
+    @PrePersist
+    void prePersist() {
+        if (enrolledAt == null) enrolledAt = Instant.now();
+        if (status == null) status = EnrollmentStatus.ACTIVE;
+    }
+}

--- a/src/main/java/com/ironhack/lms/domain/enrollment/EnrollmentStatus.java
+++ b/src/main/java/com/ironhack/lms/domain/enrollment/EnrollmentStatus.java
@@ -1,0 +1,3 @@
+package com.ironhack.lms.domain.enrollment;
+
+public enum EnrollmentStatus { ACTIVE, CANCELLED, COMPLETED }

--- a/src/main/java/com/ironhack/lms/domain/user/Instructor.java
+++ b/src/main/java/com/ironhack/lms/domain/user/Instructor.java
@@ -1,0 +1,18 @@
+package com.ironhack.lms.domain.user;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter @Setter
+@NoArgsConstructor
+@SuperBuilder
+@Entity
+@DiscriminatorValue("INSTRUCTOR")
+public class Instructor extends User {
+
+    @Column(name = "bio", columnDefinition = "TEXT")
+    private String bio;
+}

--- a/src/main/java/com/ironhack/lms/domain/user/Role.java
+++ b/src/main/java/com/ironhack/lms/domain/user/Role.java
@@ -1,0 +1,3 @@
+package com.ironhack.lms.domain.user;
+
+public enum Role { ADMIN, INSTRUCTOR, STUDENT }

--- a/src/main/java/com/ironhack/lms/domain/user/Student.java
+++ b/src/main/java/com/ironhack/lms/domain/user/Student.java
@@ -1,0 +1,18 @@
+package com.ironhack.lms.domain.user;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter @Setter
+@NoArgsConstructor
+@SuperBuilder
+@Entity
+@DiscriminatorValue("STUDENT")
+public class Student extends User {
+
+    @Column(name = "student_number", length = 64)
+    private String studentNumber;
+}

--- a/src/main/java/com/ironhack/lms/domain/user/User.java
+++ b/src/main/java/com/ironhack/lms/domain/user/User.java
@@ -1,0 +1,43 @@
+package com.ironhack.lms.domain.user;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.time.Instant;
+
+@Getter @Setter
+@NoArgsConstructor
+@SuperBuilder
+@Entity
+@Table(name = "app_user")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "dtype")
+public abstract class User {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 255)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false, length = 255)
+    private String passwordHash;
+
+    @Column(name = "full_name", nullable = false, length = 255)
+    private String fullName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private Role role;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    void prePersist() {
+        if (createdAt == null) createdAt = Instant.now();
+    }
+}

--- a/src/main/java/com/ironhack/lms/repository/course/AssignmentRepository.java
+++ b/src/main/java/com/ironhack/lms/repository/course/AssignmentRepository.java
@@ -1,0 +1,10 @@
+package com.ironhack.lms.repository.course;
+
+import com.ironhack.lms.domain.course.Assignment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AssignmentRepository extends JpaRepository<Assignment, Long> {
+    List<Assignment> findByCourse_Id(Long courseId);
+}

--- a/src/main/java/com/ironhack/lms/repository/course/CourseRepository.java
+++ b/src/main/java/com/ironhack/lms/repository/course/CourseRepository.java
@@ -1,0 +1,12 @@
+package com.ironhack.lms.repository.course;
+
+import com.ironhack.lms.domain.course.Course;
+import com.ironhack.lms.domain.course.CourseStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CourseRepository extends JpaRepository<Course, Long> {
+    Page<Course> findByStatus(CourseStatus status, Pageable pageable);
+    Page<Course> findByInstructor_Id(Long instructorId, Pageable pageable);
+}

--- a/src/main/java/com/ironhack/lms/repository/course/LessonRepository.java
+++ b/src/main/java/com/ironhack/lms/repository/course/LessonRepository.java
@@ -1,0 +1,10 @@
+package com.ironhack.lms.repository.course;
+
+import com.ironhack.lms.domain.course.Lesson;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface LessonRepository extends JpaRepository<Lesson, Long> {
+    List<Lesson> findByCourse_IdOrderByOrderIndexAsc(Long courseId);
+}

--- a/src/main/java/com/ironhack/lms/repository/enrollment/EnrollmentRepository.java
+++ b/src/main/java/com/ironhack/lms/repository/enrollment/EnrollmentRepository.java
@@ -1,0 +1,16 @@
+package com.ironhack.lms.repository.enrollment;
+
+import com.ironhack.lms.domain.enrollment.Enrollment;
+import com.ironhack.lms.domain.enrollment.EnrollmentStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+    Page<Enrollment> findByStudent_Id(Long studentId, Pageable pageable);
+    Page<Enrollment> findByStudent_IdAndStatus(Long studentId, EnrollmentStatus status, Pageable pageable);
+    boolean existsByCourse_IdAndStudent_Id(Long courseId, Long studentId);
+    Optional<Enrollment> findByIdAndStudent_Id(Long id, Long studentId);
+}

--- a/src/main/java/com/ironhack/lms/repository/user/UserRepository.java
+++ b/src/main/java/com/ironhack/lms/repository/user/UserRepository.java
@@ -1,0 +1,16 @@
+package com.ironhack.lms.repository.user;
+
+import com.ironhack.lms.domain.user.Role;
+import com.ironhack.lms.domain.user.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    List<User> findByRole(Role role);
+    Page<User> findByRole(Role role, Pageable pageable);  // for paging
+}

--- a/src/main/java/com/ironhack/lms/service/auth/AppUserDetailsService.java
+++ b/src/main/java/com/ironhack/lms/service/auth/AppUserDetailsService.java
@@ -1,0 +1,33 @@
+package com.ironhack.lms.service.auth;
+
+import com.ironhack.lms.domain.user.User;
+import com.ironhack.lms.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AppUserDetailsService implements UserDetailsService {
+
+    private final UserRepository users;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User u = users.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        List<GrantedAuthority> auth = List.of(new SimpleGrantedAuthority("ROLE_" + u.getRole().name()));
+        return org.springframework.security.core.userdetails.User
+                .withUsername(u.getEmail())
+                .password(u.getPasswordHash())
+                .authorities(auth)
+                .accountLocked(false).accountExpired(false).credentialsExpired(false).disabled(false)
+                .build();
+    }
+}

--- a/src/main/java/com/ironhack/lms/service/auth/JwtService.java
+++ b/src/main/java/com/ironhack/lms/service/auth/JwtService.java
@@ -1,0 +1,60 @@
+package com.ironhack.lms.service.auth;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    @Value("${app.jwt.secret}")
+    private String secret; // at least 32 chars for HS256
+
+    @Value("${app.jwt.expiration-minutes:120}")
+    private long expirationMin;
+
+    private SecretKey key;
+
+    @PostConstruct
+    void init() {
+        // If you prefer Base64 secrets, decode here instead of getBytes()
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateToken(UserDetails user) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .subject(user.getUsername())
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plusSeconds(expirationMin * 60)))
+                .signWith(key)            // 0.12.x: alg inferred from key (HS256)
+                .compact();
+    }
+
+    public String extractUsername(String token) {
+        return Jwts.parser()         // 0.12.x
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    public boolean isValid(String token, UserDetails user) {
+        try {
+            return extractUsername(token).equals(user.getUsername());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/ironhack/lms/service/course/CourseService.java
+++ b/src/main/java/com/ironhack/lms/service/course/CourseService.java
@@ -1,0 +1,139 @@
+package com.ironhack.lms.service.course;
+
+import com.ironhack.lms.domain.course.*;
+import com.ironhack.lms.domain.user.Instructor;
+import com.ironhack.lms.domain.user.Role;
+import com.ironhack.lms.domain.user.User;
+import com.ironhack.lms.repository.course.*;
+import com.ironhack.lms.repository.user.UserRepository;
+import com.ironhack.lms.web.course.dto.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class CourseService {
+
+    private final CourseRepository courses;
+    private final LessonRepository lessons;
+    private final AssignmentRepository assignments;
+    private final UserRepository users;
+
+    // --- Queries ---
+
+    public Page<CourseResponse> listPublished(Pageable p) {
+        return courses.findByStatus(CourseStatus.PUBLISHED, p).map(this::toDto);
+    }
+
+    public CourseResponse getForRead(Long id, Authentication auth) {
+        Course c = courses.findById(id).orElseThrow(() -> notFound("Course"));
+        if (c.getStatus() == CourseStatus.PUBLISHED) return toDto(c);
+
+        // allow owner/instructor or admin to see drafts
+        if (auth != null) {
+            User u = users.findByEmail(auth.getName()).orElse(null);
+            if (u != null && (u.getRole() == Role.ADMIN ||
+                    (u.getRole() == Role.INSTRUCTOR && c.getInstructor().getId().equals(u.getId())))) {
+                return toDto(c);
+            }
+        }
+        throw notFound("Course");
+    }
+
+    // --- Commands ---
+
+    public CourseResponse createCourse(CourseCreateRequest req, Authentication auth) {
+        User u = users.findByEmail(auth.getName())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+        if (!(u instanceof Instructor instructor))
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only instructors can create courses");
+
+        Course c = new Course();
+        c.setInstructor(instructor);
+        c.setTitle(req.title());
+        c.setDescription(req.description());
+        c.setStatus(CourseStatus.DRAFT);
+        c = courses.save(c);
+        return toDto(c);
+    }
+
+    public CourseResponse updateCourse(Long id, CourseUpdateRequest req, Authentication auth) {
+        Course c = courses.findById(id).orElseThrow(() -> notFound("Course"));
+        requireOwnerOrAdmin(auth, c);
+
+        c.setTitle(req.title());
+        c.setDescription(req.description());
+        c.setStatus(req.status());
+        if (req.status() == CourseStatus.PUBLISHED && c.getPublishedAt() == null) {
+            c.setPublishedAt(Instant.now());
+        }
+        if (req.status() != CourseStatus.PUBLISHED) {
+            c.setPublishedAt(null);
+        }
+        return toDto(courses.save(c));
+    }
+
+    public void deleteCourse(Long id, Authentication auth) {
+        Course c = courses.findById(id).orElseThrow(() -> notFound("Course"));
+        requireOwnerOrAdmin(auth, c);
+        courses.delete(c);
+    }
+
+    public Long addLesson(Long courseId, LessonCreateRequest req, Authentication auth) {
+        Course c = courses.findById(courseId).orElseThrow(() -> notFound("Course"));
+        requireOwnerOrAdmin(auth, c);
+        Lesson l = new Lesson();
+        l.setCourse(c);
+        l.setTitle(req.title());
+        l.setContentUrl(req.contentUrl());
+        l.setOrderIndex(req.orderIndex());
+        return lessons.save(l).getId();
+    }
+
+    public Long addAssignment(Long courseId, AssignmentCreateRequest req, Authentication auth) {
+        Course c = courses.findById(courseId).orElseThrow(() -> notFound("Course"));
+        requireOwnerOrAdmin(auth, c);
+        Assignment a = new Assignment();
+        a.setCourse(c);
+        a.setTitle(req.title());
+        a.setInstructions(req.instructions());
+        a.setDueAt(req.dueAt());
+        a.setMaxPoints(req.maxPoints());
+        a.setAllowLate(req.allowLate());
+        return assignments.save(a).getId();
+    }
+
+    // --- helpers ---
+
+    private void requireOwnerOrAdmin(Authentication auth, Course c) {
+        if (auth == null) throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        User u = users.findByEmail(auth.getName())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+        boolean ok = u.getRole() == Role.ADMIN ||
+                (u.getRole() == Role.INSTRUCTOR && c.getInstructor().getId().equals(u.getId()));
+        if (!ok) throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+    }
+
+    private ResponseStatusException notFound(String what) {
+        return new ResponseStatusException(HttpStatus.NOT_FOUND, what + " not found");
+    }
+
+    private CourseResponse toDto(Course c) {
+        return new CourseResponse(
+                c.getId(),
+                c.getInstructor().getId(),
+                c.getTitle(),
+                c.getDescription(),
+                c.getStatus(),
+                c.getCreatedAt(),
+                c.getPublishedAt()
+        );
+    }
+}

--- a/src/main/java/com/ironhack/lms/service/enrollment/EnrollmentService.java
+++ b/src/main/java/com/ironhack/lms/service/enrollment/EnrollmentService.java
@@ -1,0 +1,110 @@
+package com.ironhack.lms.service.enrollment;
+
+import com.ironhack.lms.domain.course.Course;
+import com.ironhack.lms.domain.course.CourseStatus;
+import com.ironhack.lms.domain.enrollment.Enrollment;
+import com.ironhack.lms.domain.enrollment.EnrollmentStatus;
+import com.ironhack.lms.domain.user.Role;
+import com.ironhack.lms.domain.user.Student;
+import com.ironhack.lms.domain.user.User;
+import com.ironhack.lms.repository.course.CourseRepository;
+import com.ironhack.lms.repository.enrollment.EnrollmentRepository;
+import com.ironhack.lms.repository.user.UserRepository;
+import com.ironhack.lms.web.enrollment.dto.EnrollmentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class EnrollmentService {
+
+    private final EnrollmentRepository enrollments;
+    private final CourseRepository courses;
+    private final UserRepository users;
+
+    // --- Queries ---
+
+    public Page<EnrollmentResponse> myEnrollments(Authentication auth, Pageable pageable) {
+        Student me = requireStudent(auth);
+        return enrollments.findByStudent_Id(me.getId(), pageable).map(this::toDto);
+    }
+
+    // --- Commands ---
+
+    public EnrollmentResponse enroll(Long courseId, Authentication auth) {
+        Student me = requireStudent(auth);
+        Course c = courses.findById(courseId).orElseThrow(() -> notFound("Course"));
+
+        if (c.getStatus() != CourseStatus.PUBLISHED) {
+            // hide drafts: as a student you cannot enroll into non-published courses
+            throw notFound("Course");
+        }
+        if (enrollments.existsByCourse_IdAndStudent_Id(courseId, me.getId())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Already enrolled");
+        }
+
+        Enrollment e = new Enrollment();
+        e.setCourse(c);
+        e.setStudent(me);
+        e = enrollments.save(e);
+        return toDto(e);
+    }
+
+    public EnrollmentResponse cancel(Long enrollmentId, Authentication auth) {
+        Student me = requireStudent(auth);
+        Enrollment e = enrollments.findByIdAndStudent_Id(enrollmentId, me.getId())
+                .orElseThrow(() -> notFound("Enrollment"));
+        e.setStatus(EnrollmentStatus.CANCELLED);
+        return toDto(enrollments.save(e));
+    }
+
+    public EnrollmentResponse completeByStaff(Long enrollmentId, Authentication auth) {
+        var staff = users.findByEmail(auth.getName())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+
+        var e = enrollments.findById(enrollmentId)
+                .orElseThrow(() -> notFound("Enrollment"));
+
+        boolean isAdmin = staff.getRole() == Role.ADMIN;
+        boolean isOwnerInstructor = staff.getRole() == Role.INSTRUCTOR
+                && e.getCourse().getInstructor().getId().equals(staff.getId());
+
+        if (!isAdmin && !isOwnerInstructor) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+        }
+
+        e.setStatus(EnrollmentStatus.COMPLETED);
+        return toDto(enrollments.save(e));
+    }
+
+    // --- helpers ---
+
+    private Student requireStudent(Authentication auth) {
+        if (auth == null) throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        User u = users.findByEmail(auth.getName())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED));
+        if (u.getRole() != Role.STUDENT || !(u instanceof Student s)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only students can enroll");
+        }
+        return s;
+    }
+
+    private ResponseStatusException notFound(String what) {
+        return new ResponseStatusException(HttpStatus.NOT_FOUND, what + " not found");
+    }
+
+    private EnrollmentResponse toDto(Enrollment e) {
+        return new EnrollmentResponse(
+                e.getId(),
+                e.getCourse().getId(),
+                e.getCourse().getTitle(),
+                e.getStatus(),
+                e.getEnrolledAt()
+        );
+    }
+}

--- a/src/main/java/com/ironhack/lms/web/ProbeController.java
+++ b/src/main/java/com/ironhack/lms/web/ProbeController.java
@@ -1,0 +1,16 @@
+package com.ironhack.lms.web;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.util.Map;
+
+@RestController
+public class ProbeController {
+    @GetMapping("/api/ping")
+    public ResponseEntity<Map<String, Object>> ping() {
+        return ResponseEntity.ok(Map.of("status", "ok", "at", Instant.now().toString()));
+    }
+}

--- a/src/main/java/com/ironhack/lms/web/WhoAmIController.java
+++ b/src/main/java/com/ironhack/lms/web/WhoAmIController.java
@@ -1,0 +1,15 @@
+package com.ironhack.lms.web;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+public class WhoAmIController {
+    @GetMapping("/api/me")
+    public Map<String,Object> me(Authentication auth) {
+        return Map.of("username", auth.getName(), "authorities", auth.getAuthorities());
+    }
+}

--- a/src/main/java/com/ironhack/lms/web/auth/AuthController.java
+++ b/src/main/java/com/ironhack/lms/web/auth/AuthController.java
@@ -1,0 +1,28 @@
+package com.ironhack.lms.web.auth;
+
+import com.ironhack.lms.service.auth.JwtService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthenticationManager authManager;
+    private final JwtService jwt;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest req) {
+        Authentication auth = authManager.authenticate(
+                new UsernamePasswordAuthenticationToken(req.email(), req.password()));
+        String token = jwt.generateToken((UserDetails) auth.getPrincipal());
+        return ResponseEntity.ok(new LoginResponse(token));
+    }
+}

--- a/src/main/java/com/ironhack/lms/web/auth/LoginRequest.java
+++ b/src/main/java/com/ironhack/lms/web/auth/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.ironhack.lms.web.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @Email @NotBlank String email,
+        @NotBlank String password
+) {}

--- a/src/main/java/com/ironhack/lms/web/auth/LoginResponse.java
+++ b/src/main/java/com/ironhack/lms/web/auth/LoginResponse.java
@@ -1,0 +1,3 @@
+package com.ironhack.lms.web.auth;
+
+public record LoginResponse(String token) {}

--- a/src/main/java/com/ironhack/lms/web/course/CourseController.java
+++ b/src/main/java/com/ironhack/lms/web/course/CourseController.java
@@ -1,0 +1,72 @@
+package com.ironhack.lms.web.course;
+
+import com.ironhack.lms.service.course.CourseService;
+import com.ironhack.lms.web.course.dto.*;
+import jakarta.annotation.security.PermitAll;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/courses")
+@RequiredArgsConstructor
+public class CourseController {
+
+    private final CourseService service;
+
+    // ---- Public reads ----
+    @PermitAll
+    @GetMapping
+    public Page<CourseResponse> listPublished(Pageable pageable) {
+        return service.listPublished(pageable);
+    }
+
+    @PermitAll
+    @GetMapping("/{id}")
+    public CourseResponse get(@PathVariable Long id, Authentication auth) {
+        return service.getForRead(id, auth);
+    }
+
+    // ---- Writes (instructor/admin) ----
+    @PreAuthorize("hasRole('INSTRUCTOR')")
+    @PostMapping
+    public CourseResponse create(@Valid @RequestBody CourseCreateRequest req, Authentication auth) {
+        return service.createCourse(req, auth);
+    }
+
+    @PreAuthorize("hasAnyRole('INSTRUCTOR','ADMIN')")
+    @PutMapping("/{id}")
+    public CourseResponse update(@PathVariable Long id,
+                                 @Valid @RequestBody CourseUpdateRequest req,
+                                 Authentication auth) {
+        return service.updateCourse(id, req, auth);
+    }
+
+    @PreAuthorize("hasAnyRole('INSTRUCTOR','ADMIN')")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id, Authentication auth) {
+        service.deleteCourse(id, auth);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PreAuthorize("hasAnyRole('INSTRUCTOR','ADMIN')")
+    @PostMapping("/{id}/lessons")
+    public ResponseEntity<Long> addLesson(@PathVariable Long id,
+                                          @Valid @RequestBody LessonCreateRequest req,
+                                          Authentication auth) {
+        return ResponseEntity.ok(service.addLesson(id, req, auth));
+    }
+
+    @PreAuthorize("hasAnyRole('INSTRUCTOR','ADMIN')")
+    @PostMapping("/{id}/assignments")
+    public ResponseEntity<Long> addAssignment(@PathVariable Long id,
+                                              @Valid @RequestBody AssignmentCreateRequest req,
+                                              Authentication auth) {
+        return ResponseEntity.ok(service.addAssignment(id, req, auth));
+    }
+}

--- a/src/main/java/com/ironhack/lms/web/course/dto/AssignmentCreateRequest.java
+++ b/src/main/java/com/ironhack/lms/web/course/dto/AssignmentCreateRequest.java
@@ -1,0 +1,14 @@
+package com.ironhack.lms.web.course.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+
+public record AssignmentCreateRequest(
+        @NotBlank @Size(max = 200) String title,
+        @Size(max = 50000) String instructions,
+        Instant dueAt,
+        @Min(1) int maxPoints,
+        boolean allowLate
+) {}

--- a/src/main/java/com/ironhack/lms/web/course/dto/CourseCreateRequest.java
+++ b/src/main/java/com/ironhack/lms/web/course/dto/CourseCreateRequest.java
@@ -1,0 +1,9 @@
+package com.ironhack.lms.web.course.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CourseCreateRequest(
+        @NotBlank @Size(max = 200) String title,
+        @Size(max = 20000) String description
+) {}

--- a/src/main/java/com/ironhack/lms/web/course/dto/CourseResponse.java
+++ b/src/main/java/com/ironhack/lms/web/course/dto/CourseResponse.java
@@ -1,0 +1,14 @@
+package com.ironhack.lms.web.course.dto;
+
+import com.ironhack.lms.domain.course.CourseStatus;
+import java.time.Instant;
+
+public record CourseResponse(
+        Long id,
+        Long instructorId,
+        String title,
+        String description,
+        CourseStatus status,
+        Instant createdAt,
+        Instant publishedAt
+) {}

--- a/src/main/java/com/ironhack/lms/web/course/dto/CourseUpdateRequest.java
+++ b/src/main/java/com/ironhack/lms/web/course/dto/CourseUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.ironhack.lms.web.course.dto;
+
+import com.ironhack.lms.domain.course.CourseStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CourseUpdateRequest(
+        @NotBlank @Size(max = 200) String title,
+        @Size(max = 20000) String description,
+        @NotNull CourseStatus status
+) {}

--- a/src/main/java/com/ironhack/lms/web/course/dto/LessonCreateRequest.java
+++ b/src/main/java/com/ironhack/lms/web/course/dto/LessonCreateRequest.java
@@ -1,0 +1,11 @@
+package com.ironhack.lms.web.course.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record LessonCreateRequest(
+        @NotBlank @Size(max = 200) String title,
+        @Size(max = 2048) String contentUrl,
+        @Min(1) int orderIndex
+) {}

--- a/src/main/java/com/ironhack/lms/web/enrollment/EnrollmentController.java
+++ b/src/main/java/com/ironhack/lms/web/enrollment/EnrollmentController.java
@@ -1,0 +1,46 @@
+package com.ironhack.lms.web.enrollment;
+
+import com.ironhack.lms.service.enrollment.EnrollmentService;
+import com.ironhack.lms.web.enrollment.dto.EnrollmentResponse;
+import jakarta.annotation.security.RolesAllowed;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class EnrollmentController {
+
+    private final EnrollmentService service;
+
+    // Enroll in a published course
+    @RolesAllowed("STUDENT")
+    @PostMapping("/api/courses/{courseId}/enroll")
+    public ResponseEntity<EnrollmentResponse> enroll(@PathVariable Long courseId, Authentication auth) {
+        return ResponseEntity.ok(service.enroll(courseId, auth));
+    }
+
+    // My enrollments
+    @RolesAllowed("STUDENT")
+    @GetMapping("/api/enrollments")
+    public Page<EnrollmentResponse> myEnrollments(Authentication auth, Pageable pageable) {
+        return service.myEnrollments(auth, pageable);
+    }
+
+    // Cancel my enrollment
+    @RolesAllowed("STUDENT")
+    @PatchMapping("/api/enrollments/{id}/cancel")
+    public EnrollmentResponse cancel(@PathVariable Long id, Authentication auth) {
+        return service.cancel(id, auth);
+    }
+
+    // Mark as completed
+    @RolesAllowed({ "INSTRUCTOR", "ADMIN" })
+    @PatchMapping("/api/enrollments/{id}/complete")
+    public EnrollmentResponse complete(@PathVariable Long id, Authentication auth) {
+        return service.completeByStaff(id, auth);
+    }
+}

--- a/src/main/java/com/ironhack/lms/web/enrollment/dto/EnrollmentResponse.java
+++ b/src/main/java/com/ironhack/lms/web/enrollment/dto/EnrollmentResponse.java
@@ -1,0 +1,12 @@
+package com.ironhack.lms.web.enrollment.dto;
+
+import com.ironhack.lms.domain.enrollment.EnrollmentStatus;
+import java.time.Instant;
+
+public record EnrollmentResponse(
+        Long id,
+        Long courseId,
+        String courseTitle,
+        EnrollmentStatus status,
+        Instant enrolledAt
+) {}

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,10 @@
+spring.datasource.url=jdbc:h2:mem:ironlms;MODE=MySQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=true
+spring.flyway.enabled=false
+app.jwt.secret=test-secret-32-characters-minimum-1234567890
+app.jwt.expiration-minutes=60

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,37 @@
+# App
 spring.application.name=lms
+
+# Server
+server.port=3315
+
+# --- DataSource (MySQL local) ---
+# Adjust the port if your MySQL isn't on 3314
+spring.datasource.url=jdbc:mysql://localhost:3314/lms?createDatabaseIfNotExist=true&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+spring.datasource.username=root
+spring.datasource.password=ironhack
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+# --- JPA / Hibernate ---
+# Let Flyway own the schema later; for now 'validate' keeps you safe.
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.open-in-view=false
+# (Hibernate 6 auto-detects the dialect; no need to force it)
+# spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+
+# Dev-only SQL logging (comment out if noisy)
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+# logging.level.org.hibernate.SQL=debug
+# logging.level.org.hibernate.orm.jdbc.bind=trace
+
+# Timezone consistency
+spring.jpa.properties.hibernate.jdbc.time_zone=UTC
+spring.jackson.time-zone=UTC
+
+# --- Flyway (migrations) ---
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+
+# JWT
+app.jwt.secret=ChangeMe_ToA_LongRandomString_AtLeast32Chars_1234567890
+app.jwt.expiration-minutes=120

--- a/src/main/resources/db/migration/V1__init_users.sql
+++ b/src/main/resources/db/migration/V1__init_users.sql
@@ -1,0 +1,20 @@
+-- Single-table inheritance for User / Student / Instructor
+-- We avoid table name "user" (reserved) and use app_user instead.
+CREATE TABLE IF NOT EXISTS app_user (
+  id               BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  dtype            VARCHAR(31)      NOT NULL,         -- discriminator: USER/STUDENT/INSTRUCTOR
+  email            VARCHAR(255)     NOT NULL,
+  password_hash    VARCHAR(255)     NOT NULL,
+  full_name        VARCHAR(255)     NOT NULL,
+  role             VARCHAR(32)      NOT NULL,         -- ADMIN / INSTRUCTOR / STUDENT
+  created_at       DATETIME(3)      NOT NULL,
+
+  -- Child-specific fields (nullable in SINGLE_TABLE)
+  student_number   VARCHAR(64)      NULL,
+  bio              TEXT             NULL,
+
+  CONSTRAINT uq_app_user_email UNIQUE (email)
+);
+
+CREATE INDEX idx_app_user_role ON app_user(role);
+CREATE INDEX idx_app_user_dtype ON app_user(dtype);

--- a/src/main/resources/db/migration/V2__content.sql
+++ b/src/main/resources/db/migration/V2__content.sql
@@ -1,0 +1,46 @@
+-- Courses (created by an Instructor)
+CREATE TABLE IF NOT EXISTS course (
+  id            BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  instructor_id BIGINT NOT NULL,
+  title         VARCHAR(200) NOT NULL,
+  description   TEXT NULL,
+  status        VARCHAR(20) NOT NULL,
+  created_at    DATETIME(3) NOT NULL,
+  published_at  DATETIME(3) NULL,
+  CONSTRAINT fk_course_instructor
+    FOREIGN KEY (instructor_id) REFERENCES app_user(id)
+);
+
+CREATE INDEX idx_course_status       ON course(status);
+CREATE INDEX idx_course_instructor   ON course(instructor_id);
+
+-- Lessons in a course
+CREATE TABLE IF NOT EXISTS lesson (
+  id            BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  course_id     BIGINT NOT NULL,
+  title         VARCHAR(200) NOT NULL,
+  content_url   VARCHAR(2048) NULL,
+  order_index   INT NOT NULL,
+  CONSTRAINT fk_lesson_course
+    FOREIGN KEY (course_id) REFERENCES course(id)
+      ON DELETE CASCADE
+);
+
+CREATE INDEX idx_lesson_course       ON lesson(course_id);
+CREATE UNIQUE INDEX uq_lesson_order  ON lesson(course_id, order_index);
+
+-- Assignments in a course
+CREATE TABLE IF NOT EXISTS assignment (
+  id            BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  course_id     BIGINT NOT NULL,
+  title         VARCHAR(200) NOT NULL,
+  instructions  TEXT NULL,
+  due_at        DATETIME(3) NULL,
+  max_points    INT NOT NULL,
+  allow_late    BOOLEAN NOT NULL,
+  CONSTRAINT fk_assignment_course
+    FOREIGN KEY (course_id) REFERENCES course(id)
+      ON DELETE CASCADE
+);
+
+CREATE INDEX idx_assignment_course ON assignment(course_id);

--- a/src/main/resources/db/migration/V3__enrollment.sql
+++ b/src/main/resources/db/migration/V3__enrollment.sql
@@ -1,0 +1,18 @@
+-- Student enrolls into a Course
+CREATE TABLE IF NOT EXISTS enrollment (
+  id           BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  student_id   BIGINT NOT NULL,
+  course_id    BIGINT NOT NULL,
+  enrolled_at  DATETIME(3) NOT NULL,
+  status       VARCHAR(20) NOT NULL,
+
+  CONSTRAINT fk_enroll_student FOREIGN KEY (student_id) REFERENCES app_user(id)
+    ON DELETE CASCADE,
+  CONSTRAINT fk_enroll_course  FOREIGN KEY (course_id)  REFERENCES course(id)
+    ON DELETE CASCADE,
+  CONSTRAINT uq_enroll UNIQUE (student_id, course_id)
+);
+
+CREATE INDEX idx_enroll_student ON enrollment(student_id);
+CREATE INDEX idx_enroll_course  ON enrollment(course_id);
+CREATE INDEX idx_enroll_status  ON enrollment(status);

--- a/src/test/java/com/ironhack/lms/repository/UserRepositoryTests.java
+++ b/src/test/java/com/ironhack/lms/repository/UserRepositoryTests.java
@@ -1,0 +1,45 @@
+package com.ironhack.lms.repository;
+
+
+import com.ironhack.lms.domain.user.Instructor;
+import com.ironhack.lms.domain.user.Role;
+import com.ironhack.lms.domain.user.Student;
+import com.ironhack.lms.repository.user.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class UserRepositoryTests {
+
+    @Autowired
+    UserRepository repo;
+
+    @Test
+    void saveAndFind_studentAndInstructor() {
+        Student s = Student.builder()
+                .email("student@lms.local")
+                .passwordHash("password")  // we'll hash later
+                .fullName("Stu Dent")
+                .role(Role.STUDENT)
+                .build();
+        repo.save(s);
+
+        Instructor i = Instructor.builder()
+                .email("instructor@lms.local")
+                .passwordHash("password")
+                .fullName("In Structor")
+                .role(Role.INSTRUCTOR)
+                .build();
+        repo.save(i);
+
+        assertThat(repo.findByEmail("student@lms.local")).isPresent();
+        assertThat(repo.findByEmail("instructor@lms.local")).isPresent();
+        assertThat(repo.findByRole(Role.STUDENT)).hasSize(1);
+        assertThat(repo.findByRole(Role.INSTRUCTOR)).hasSize(1);
+    }
+}

--- a/src/test/java/com/ironhack/lms/web/ProbeControllerTests.java
+++ b/src/test/java/com/ironhack/lms/web/ProbeControllerTests.java
@@ -1,0 +1,39 @@
+package com.ironhack.lms.web;
+
+import org.testng.annotations.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration test for /api/ping.
+ *
+ * Notes:
+ * - Uses MockMvc (no real HTTP port needed).
+ * - @AutoConfigureTestDatabase swaps your MySQL DataSource with in-memory H2 for tests,
+ *   so MySQL doesn’t need to be running.
+ * - Because the class name ends with *IT, Maven will only run it if you use the Failsafe plugin
+ *   (mvn verify) or you rename it to *Tests to run with Surefire (mvn test).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = Replace.ANY)
+class ProbeControllerTests {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void ping_returnsOk() throws Exception {
+        mvc.perform(get("/api/ping"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ok"));
+    }
+}


### PR DESCRIPTION
feat(enrollment): enrollments lifecycle (ACTIVE/CANCELLED/COMPLETED)
- Flyway V3__enrollment.sql: enrollment table + FKs + unique(student,course)
- Domain: Enrollment, EnrollmentStatus
- Repo: EnrollmentRepository (queries, existence checks)
- Service: enroll/cancel for students; completion by instructor/admin
- Controller: POST /api/courses/{id}/enroll, GET /api/enrollments, PATCH /api/enrollments/{id}/cancel, PATCH /api/enrollments/{id}/complete
- Security: restrict enroll/cancel to ROLE_STUDENT; completion to ROLE_INSTRUCTOR/ADMIN
- DTO: EnrollmentResponse