### PR TITLE
feat: add public reads for published content and role guards

### DIFF
--- a/src/main/java/com/ironhack/lms/service/course/CourseService.java
+++ b/src/main/java/com/ironhack/lms/service/course/CourseService.java
@@ -176,4 +176,25 @@ public class CourseService {
                 c.getPublishedAt()
         );
     }
+
+    public java.util.List<LessonSummaryResponse> listLessonsForRead(Long courseId, Authentication auth) {
+        Course c = courses.findById(courseId).orElseThrow(() -> notFound("Course"));
+        if (c.getStatus() != CourseStatus.PUBLISHED) {
+            requireOwnerOrAdmin(auth, c); // throws 401/403 if not allowed
+        }
+        return lessons.findByCourse_IdOrderByOrderIndexAsc(courseId).stream()
+                .map(l -> new LessonSummaryResponse(l.getId(), l.getTitle(), l.getContentUrl(), l.getOrderIndex()))
+                .toList();
+    }
+
+    public java.util.List<AssignmentSummaryResponse> listAssignmentsForRead(Long courseId, Authentication auth) {
+        Course c = courses.findById(courseId).orElseThrow(() -> notFound("Course"));
+        if (c.getStatus() != CourseStatus.PUBLISHED) {
+            requireOwnerOrAdmin(auth, c);
+        }
+        return assignments.findByCourse_Id(courseId).stream()
+                .map(a -> new AssignmentSummaryResponse(a.getId(), a.getTitle(), a.getInstructions(),
+                        a.getMaxPoints(), a.isAllowLate(), a.getDueAt()))
+                .toList();
+    }
 }

--- a/src/main/java/com/ironhack/lms/web/ErrorHandler.java
+++ b/src/main/java/com/ironhack/lms/web/ErrorHandler.java
@@ -4,6 +4,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BindException;
 import org.springframework.web.ErrorResponseException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -12,6 +14,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import jakarta.validation.ConstraintViolationException;
+import org.springframework.web.server.ResponseStatusException;
+
 import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -78,6 +82,23 @@ public class ErrorHandler {
 
     @ExceptionHandler(ErrorResponseException.class)
     public ProblemDetail handleSpringErrors(ErrorResponseException ex) {
+        return ex.getBody();
+    }
+
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ProblemDetail handleAuthentication(AuthenticationException ex) {
+        return ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, "Unauthorized");
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ProblemDetail handleAccessDenied(AccessDeniedException ex) {
+        return ProblemDetail.forStatusAndDetail(HttpStatus.FORBIDDEN, "Forbidden");
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ProblemDetail handleResponseStatus(ResponseStatusException ex) {
+        // Preserve the status set by your service/controller (e.g., FORBIDDEN, NOT_FOUND, CONFLICT)
         return ex.getBody();
     }
 

--- a/src/main/java/com/ironhack/lms/web/course/CourseController.java
+++ b/src/main/java/com/ironhack/lms/web/course/CourseController.java
@@ -107,4 +107,16 @@ public class CourseController {
         service.deleteAssignment(courseId, assignmentId, auth);
         return ResponseEntity.noContent().build();
     }
+
+    @PermitAll
+    @GetMapping("/{id}/lessons")
+    public java.util.List<LessonSummaryResponse> lessons(@PathVariable Long id, Authentication auth) {
+        return service.listLessonsForRead(id, auth);
+    }
+
+    @PermitAll
+    @GetMapping("/{id}/assignments")
+    public java.util.List<AssignmentSummaryResponse> assignments(@PathVariable Long id, Authentication auth) {
+        return service.listAssignmentsForRead(id, auth);
+    }
 }

--- a/src/main/java/com/ironhack/lms/web/course/dto/AssignmentSummaryResponse.java
+++ b/src/main/java/com/ironhack/lms/web/course/dto/AssignmentSummaryResponse.java
@@ -1,0 +1,12 @@
+package com.ironhack.lms.web.course.dto;
+
+import java.time.Instant;
+
+public record AssignmentSummaryResponse(
+        Long id,
+        String title,
+        String instructions,
+        Integer maxPoints,
+        boolean allowLate,
+        Instant dueAt
+) {}

--- a/src/main/java/com/ironhack/lms/web/course/dto/LessonSummaryResponse.java
+++ b/src/main/java/com/ironhack/lms/web/course/dto/LessonSummaryResponse.java
@@ -1,0 +1,8 @@
+package com.ironhack.lms.web.course.dto;
+
+public record LessonSummaryResponse(
+        Long id,
+        String title,
+        String contentUrl,
+        int orderIndex
+) {}

--- a/src/test/java/com/ironhack/lms/web/course/CourseAuthzIT.java
+++ b/src/test/java/com/ironhack/lms/web/course/CourseAuthzIT.java
@@ -1,0 +1,125 @@
+package com.ironhack.lms.web.course;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Verifies: public reads for published, draft hidden to anon,
+ * instructor can manage, student can't write.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class CourseAuthzIT {
+
+    @Autowired
+    MockMvc mvc;
+    @Autowired
+    ObjectMapper om;
+
+    private String login(String email, String password) throws Exception {
+        var body = om.writeValueAsString(new Login(email, password));
+        var json = mvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        return om.readTree(json).get("token").asText();
+    }
+
+    record Login(String email, String password) {
+    }
+
+    @Test
+    void public_can_list_published_courses_and_nested_content() throws Exception {
+        // list published
+        mvc.perform(get("/api/courses").param("page", "0").param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", not(empty())));
+
+        // pick first course id from list
+        var json = mvc.perform(get("/api/courses?page=0&size=1"))
+                .andReturn().getResponse().getContentAsString();
+        long id = Long.parseLong(om.readTree(json).get("content").get(0).get("id").asText());
+
+        // course detail is readable
+        mvc.perform(get("/api/courses/{id}", id))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", is("PUBLISHED")));
+
+        // lessons & assignments endpoints are readable too
+        mvc.perform(get("/api/courses/{id}/lessons", id))
+                .andExpect(status().isOk());
+
+        mvc.perform(get("/api/courses/{id}/assignments", id))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void draft_hidden_to_anon_but_visible_to_owner() throws Exception {
+        // login as instructor and create a DRAFT course
+        var instr = login("instructor@lms.local", "password");
+
+        var create = """
+                {"title":"Draft X","description":"internal"}
+                """;
+        var created = mvc.perform(post("/api/courses")
+                        .header("Authorization", "Bearer " + instr)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(create))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        long draftId = om.readTree(created).get("id").asLong();
+
+        // anon cannot see draft detail
+        mvc.perform(get("/api/courses/{id}", draftId))
+                .andExpect(status().isNotFound());
+
+        // owner (instructor) can
+        mvc.perform(get("/api/courses/{id}", draftId)
+                        .header("Authorization", "Bearer " + instr))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void student_cannot_create_course_and_anon_gets_401_on_writes() throws Exception {
+        // 1) create draft course payload
+        var create = """
+                {
+                "title": "Draft X",
+                "description": "internal"
+                }
+                """;
+
+        // 2) anon create (use the same or a separate block)
+        var payloadNope = """
+                {
+                  "title": "Nope",
+                  "description": "-"
+                }
+                """;
+
+        mvc.perform(post("/api/courses")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payloadNope))
+                .andExpect(status().isUnauthorized());
+
+        var student = login("student@lms.local", "password");
+
+        mvc.perform(post("/api/courses")
+                        .header("Authorization", "Bearer " + student)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payloadNope))
+                .andExpect(status().isForbidden());
+
+    }
+}


### PR DESCRIPTION
public reads for published content + role guards
- Add public GET endpoints: /api/courses/{id}/lessons and /api/courses/{id}/assignments
- Service guards: hide drafts from anonymous; allow owner/admin
- Confirm SecurityConfig permits GET /api/courses/**
- Add MockMvc ITs for public/draft/role access (CourseAuthzIT)